### PR TITLE
Ruby 3.1 compatibility

### DIFF
--- a/lib/fixation/fixture_table.rb
+++ b/lib/fixation/fixture_table.rb
@@ -38,7 +38,7 @@ module Fixation
     end
 
     def parsed_rows
-      result = YAML.load(self.class.erb_content(filename))
+      result = YAML.unsafe_load(self.class.erb_content(filename))
       result ||= {} # for completely empty files
 
       unless (result.is_a?(Hash) || result.is_a?(YAML::Omap)) && result.all? { |name, attributes| name.is_a?(String) && attributes.is_a?(Hash) }


### PR DESCRIPTION
Enables correct Ruby 3.1+ compatabilty, as prior to Ruby 3.1, Psych's load method was aliased to unsafe_load, so this change preserves the original functionality