### PR TITLE
Correct version number

### DIFF
--- a/lib/fixation/version.rb
+++ b/lib/fixation/version.rb
@@ -1,3 +1,3 @@
 module Fixation
-  VERSION = "2.6.0"
+  VERSION = "2.8.0"
 end


### PR DESCRIPTION
Accidentally forgot to bump the version number. Didn't want to mess around with rewriting tags, so just bumped up a version